### PR TITLE
fhir_r5_auth 0.7.2: second security hardening pass

### DIFF
--- a/packages/fhir_r5_auth/CHANGELOG.md
+++ b/packages/fhir_r5_auth/CHANGELOG.md
@@ -1,5 +1,19 @@
 # fhir_r5_auth
 
+## [0.7.2]
+
+Second security hardening pass (library code only; fhir_r5 core unchanged at ^0.7.0):
+
+- Fixed a broken concurrency guard where the "prevent concurrent refreshes" lock was permanently completed and did nothing — parallel refreshes are now coalesced into a single token exchange. This prevents refresh-token-rotation servers from rejecting a racing refresh and invalidating the token family.
+- Refresh no longer discards the refresh token when the server omits it from a refresh response (RFC 6749 §6) — the existing refresh token is carried forward instead of being nulled out.
+- TLS is now enforced on the SMART discovery documents (`.well-known/smart-configuration` and `/metadata`) and on the token introspection endpoint, closing the remaining plaintext paths (loopback still allowed; `allowInsecureConnections` opt-out).
+- The bearer token is now origin-bound: it is attached only to requests whose scheme/host/port match the configured FHIR server, so it cannot leak to another host.
+- `SmartConfig.fromLaunchParameters` accepts an `allowedIssuers` set and rejects an EHR-launch `iss` that is not allowlisted (mitigates SMART "iss spoofing" token theft).
+- JWT verification enforces an algorithm allowlist (rejects `alg: none` and unknown algorithms) and rejects tokens carrying their own key material or key references (`jwk`/`jku`/`x5u`/`x5c`).
+- Client-assertion JWTs (`createSignedJwt`) now use a random UUID `jti` instead of a timestamp.
+- PKCE can no longer be disabled for a public SMART client.
+- `at_hash`, nonce, and PKCE challenge comparisons now use a constant-time equality check.
+
 ## [0.7.1]
 
 Security hardening of the SMART on FHIR auth flow (auth-only patch; fhir_r5 core unchanged at ^0.7.0):

--- a/packages/fhir_r5_auth/lib/src/core/auth_client.dart
+++ b/packages/fhir_r5_auth/lib/src/core/auth_client.dart
@@ -44,8 +44,14 @@ abstract class FhirAuthClient extends http.BaseClient {
   /// Current token response
   SmartTokenResponse? _currentTokens;
 
-  /// Lock for token refresh to prevent concurrent refreshes
-  final _refreshLock = Completer<void>()..complete();
+  /// The in-flight refresh operation, if one is running.
+  ///
+  /// Concurrent callers await this same future instead of starting their own
+  /// refresh, so a burst of expired-token requests triggers exactly one token
+  /// exchange. This matters with refresh-token rotation: parallel refreshes
+  /// would each present the same refresh token, and the second would be
+  /// rejected (and can invalidate the whole token family).
+  Future<void>? _refreshInFlight;
 
   /// Get FHIR base URL
   FhirUri get fhirBaseUrl => config.fhirBaseUrl;
@@ -96,46 +102,43 @@ abstract class FhirAuthClient extends http.BaseClient {
   /// Hook for subclasses to handle logout
   Future<void> onLogout() async {}
 
-  /// Refresh the access token
-  Future<void> refreshToken() async {
-    // Prevent concurrent refreshes
-    if (!_refreshLock.isCompleted) {
-      await _refreshLock.future;
-      return;
+  /// Refresh the access token.
+  ///
+  /// Concurrent calls are coalesced: the first starts the refresh and every
+  /// other caller awaits the same operation.
+  Future<void> refreshToken() {
+    // Assigned synchronously before any await, so concurrent callers that
+    // arrive before this refresh completes observe the same in-flight future.
+    final existing = _refreshInFlight;
+    if (existing != null) return existing;
+
+    final op = _performRefresh();
+    _refreshInFlight = op;
+    return op.whenComplete(() => _refreshInFlight = null);
+  }
+
+  Future<void> _performRefresh() async {
+    logger.fine('Refreshing access token');
+
+    final current = _currentTokens ?? await tokenStorage.loadTokens();
+
+    // Perform refresh - subclass handles the strategy
+    // (backend services re-authenticate; SMART uses refresh token)
+    final refreshTokenValue = current?.refreshToken;
+    var newTokens = await performTokenRefresh(refreshTokenValue ?? '');
+
+    // Per RFC 6749 §6, the authorization server MAY omit refresh_token from a
+    // refresh response, in which case the client keeps using the existing one.
+    // Carry it forward so we don't strand ourselves without a refresh token.
+    if (newTokens.refreshToken == null && current?.refreshToken != null) {
+      newTokens = newTokens.copyWith(refreshToken: current!.refreshToken);
     }
 
-    final lock = Completer<void>();
-    // Fire-and-forget: chain the new lock to the prior one's completion
-    // without blocking this refresh on it.
-    unawaited(_refreshLock.future.then((_) => lock.complete()));
+    // storeTokens updates in-memory state, secure storage, and auth state (and
+    // lets subclasses refresh their own token caches).
+    await storeTokens(newTokens);
 
-    try {
-      logger.fine('Refreshing access token');
-
-      final current = _currentTokens ?? await tokenStorage.loadTokens();
-
-      // Perform refresh - subclass handles the strategy
-      // (backend services re-authenticate; SMART uses refresh token)
-      final refreshTokenValue = current?.refreshToken;
-      final newTokens = await performTokenRefresh(refreshTokenValue ?? '');
-
-      // Update tokens
-      _currentTokens = newTokens;
-      await tokenStorage.saveTokens(newTokens);
-
-      // Update auth state
-      await tokenStorage.saveAuthState(
-        AuthState(
-          tokenResponse: newTokens,
-          lastAuthenticated: DateTime.now(),
-          authMethod: config.authMethod,
-        ),
-      );
-
-      logger.fine('Token refresh successful');
-    } finally {
-      lock.complete();
-    }
+    logger.fine('Token refresh successful');
   }
 
   /// Perform the actual token refresh - implemented by subclass
@@ -162,13 +165,32 @@ abstract class FhirAuthClient extends http.BaseClient {
     return _currentTokens?.accessToken;
   }
 
+  /// Whether the bearer token may be attached to a request for [url].
+  ///
+  /// The access token is bound to the configured FHIR server (its OAuth
+  /// audience). Only requests to that same origin (scheme + host + port) get
+  /// the `Authorization` header, so the token can never leak to a different
+  /// host if the client is pointed at (or redirected to) one.
+  bool _isFhirServerOrigin(Uri url) {
+    final base = Uri.parse(config.fhirBaseUrl.toString());
+    return url.scheme == base.scheme &&
+        url.host == base.host &&
+        url.port == base.port;
+  }
+
   /// Send HTTP request with authentication
   @override
   Future<http.StreamedResponse> send(http.BaseRequest request) async {
-    // Add authentication header
-    final token = await getAccessToken();
+    // Add authentication header, but only for the configured FHIR server.
+    final sameOrigin = _isFhirServerOrigin(request.url);
+    final token = sameOrigin ? await getAccessToken() : null;
     if (token != null) {
       request.headers[HttpHeaders.authorization] = 'Bearer $token';
+    } else if (!sameOrigin) {
+      logger.warning(
+        'Not attaching bearer token: request host ${request.url.host} does '
+        'not match the configured FHIR server ${config.fhirBaseUrl}',
+      );
     }
 
     // Add standard headers
@@ -182,7 +204,7 @@ abstract class FhirAuthClient extends http.BaseClient {
     var response = await innerClient.send(request);
 
     // Handle 401 Unauthorized - try to refresh/re-authenticate and retry once
-    if (response.statusCode == 401 && _currentTokens != null) {
+    if (response.statusCode == 401 && _currentTokens != null && sameOrigin) {
       logger.fine('Got 401, attempting token refresh');
 
       try {

--- a/packages/fhir_r5_auth/lib/src/core/auth_config.dart
+++ b/packages/fhir_r5_auth/lib/src/core/auth_config.dart
@@ -3,7 +3,12 @@ library;
 
 import 'package:fhir_r5/fhir_r5.dart' show FhirUri;
 import 'package:fhir_r5_auth/fhir_r5_auth.dart'
-    show ClientAuthMethod, LaunchType, SmartCapability;
+    show
+        ClientAuthMethod,
+        LaunchType,
+        SecurityException,
+        SecurityViolationType,
+        SmartCapability;
 
 /// Base configuration for FHIR authentication
 class AuthConfig {
@@ -159,6 +164,14 @@ class SmartConfig extends AuthConfig {
   }
 
   /// Create from launch parameters (e.g., from URL query)
+  ///
+  /// SECURITY: In an EHR launch the `iss` (issuer / FHIR server) comes from the
+  /// launch URL, which is attacker-controllable. A malicious launcher can point
+  /// the app at a hostile server to phish tokens and data ("iss spoofing").
+  /// Always pass [allowedIssuers] with the set of FHIR servers you trust; the
+  /// launch is rejected when `iss` is not among them. Omitting [allowedIssuers]
+  /// preserves the legacy (insecure) behavior of trusting any issuer and is
+  /// strongly discouraged in production.
   factory SmartConfig.fromLaunchParameters({
     required Map<String, String> parameters,
     required Uri currentUrl,
@@ -166,10 +179,23 @@ class SmartConfig extends AuthConfig {
     Uri? redirectUri,
     List<String>? scopes,
     String? clientSecret,
+    Set<String>? allowedIssuers,
   }) {
     // Extract SMART parameters
     final iss = parameters['iss'];
     final launch = parameters['launch'];
+
+    // Reject an untrusted issuer before it is ever used as the FHIR base URL
+    // or token audience.
+    if (allowedIssuers != null && allowedIssuers.isNotEmpty) {
+      if (iss == null || !allowedIssuers.contains(iss)) {
+        throw SecurityException(
+          'Untrusted SMART launch issuer',
+          details: 'The launch "iss" ($iss) is not in the allowed issuer list.',
+          securityViolationType: SecurityViolationType.invalidIssuer,
+        );
+      }
+    }
 
     // Determine launch type
     final launchType = launch != null ? LaunchType.ehr : LaunchType.standalone;

--- a/packages/fhir_r5_auth/lib/src/core/core.dart
+++ b/packages/fhir_r5_auth/lib/src/core/core.dart
@@ -3,6 +3,7 @@ export 'auth_client.dart';
 export 'auth_config.dart';
 export 'auth_exceptions.dart';
 export 'auth_types.dart';
+export 'crypto_utils.dart';
 export 'rate_limiter.dart';
 export 'session_manager.dart';
 export 'url_security.dart';

--- a/packages/fhir_r5_auth/lib/src/core/crypto_utils.dart
+++ b/packages/fhir_r5_auth/lib/src/core/crypto_utils.dart
@@ -1,0 +1,22 @@
+/// Small cryptographic helpers shared across the auth package.
+library;
+
+import 'dart:convert';
+
+/// Compares two strings in constant time relative to their content.
+///
+/// Returns `true` only when [a] and [b] are byte-for-byte equal. The comparison
+/// short-circuits on differing length (which is not secret for the fixed-length
+/// hashes/tokens this is used on) but otherwise inspects every byte, so it does
+/// not leak *where* two equal-length values first differ. Use this for security
+/// token comparisons (`at_hash`, nonce, PKCE challenge) instead of `==`.
+bool constantTimeEquals(String a, String b) {
+  final ab = utf8.encode(a);
+  final bb = utf8.encode(b);
+  if (ab.length != bb.length) return false;
+  var result = 0;
+  for (var i = 0; i < ab.length; i++) {
+    result |= ab[i] ^ bb[i];
+  }
+  return result == 0;
+}

--- a/packages/fhir_r5_auth/lib/src/oauth/jwt_validator.dart
+++ b/packages/fhir_r5_auth/lib/src/oauth/jwt_validator.dart
@@ -12,10 +12,12 @@ import 'package:fhir_r5_auth/fhir_r5_auth.dart'
         NetworkException,
         SecurityException,
         SecurityViolationType,
-        assertSecureAuthUrl;
+        assertSecureAuthUrl,
+        constantTimeEquals;
 import 'package:http/http.dart' as http;
 import 'package:jose/jose.dart';
 import 'package:logging/logging.dart';
+import 'package:uuid/uuid.dart';
 
 /// JWT validator for secure token verification with JWK/JWKS support
 class JwtValidator {
@@ -48,6 +50,28 @@ class JwtValidator {
   final http.Client _httpClient;
   final Logger _logger;
 
+  /// Signature algorithms accepted during verification.
+  ///
+  /// `none` is deliberately excluded — an unsigned token must never be treated
+  /// as verified. Symmetric (`HS*`) algorithms are included for the shared-
+  /// secret path; the JWKS/PEM paths use the asymmetric families.
+  static const Set<String> _allowedAlgorithms = <String>{
+    'HS256', 'HS384', 'HS512', //
+    'RS256', 'RS384', 'RS512', //
+    'ES256', 'ES384', 'ES512', //
+    'PS256', 'PS384', 'PS512', //
+  };
+
+  /// JOSE header parameters that embed or reference a key. An attacker can set
+  /// these to point verification at a key they control, so we reject any token
+  /// that carries them and rely solely on our configured trust anchors.
+  static const Set<String> _forbiddenHeaderParams = <String>{
+    'jwk',
+    'jku',
+    'x5u',
+    'x5c',
+  };
+
   /// Cache for JWKS keysets
   final Map<String, JsonWebKeyStore> _jwksCache = {};
 
@@ -69,6 +93,10 @@ class JwtValidator {
   }) async {
     try {
       _logger.fine('Validating JWT token');
+
+      // Reject dangerous headers (alg:none, embedded/attacker-referenced keys)
+      // before doing anything else with the token.
+      _assertSafeHeader(token);
 
       JsonWebToken jwt;
 
@@ -278,6 +306,55 @@ class JwtValidator {
     );
   }
 
+  /// Reject a JWT whose header is unsafe before any signature processing.
+  ///
+  /// Enforces an algorithm allowlist (notably excluding `none`) and rejects
+  /// headers that carry their own key material or a key reference
+  /// (`jwk`/`jku`/`x5u`/`x5c`), which an attacker could use to have the token
+  /// verified against a key they control.
+  void _assertSafeHeader(String token) {
+    final parts = token.split('.');
+    if (parts.length < 2) {
+      throw const SecurityException(
+        'Malformed JWT',
+        details: 'Token does not have a header and payload segment.',
+        securityViolationType: SecurityViolationType.invalidJwtSignature,
+      );
+    }
+
+    final Map<String, dynamic> header;
+    try {
+      header = jsonDecode(
+        utf8.decode(base64Url.decode(base64Url.normalize(parts[0]))),
+      ) as Map<String, dynamic>;
+    } catch (e) {
+      throw SecurityException(
+        'Malformed JWT header',
+        details: e.toString(),
+        securityViolationType: SecurityViolationType.invalidJwtSignature,
+      );
+    }
+
+    for (final param in _forbiddenHeaderParams) {
+      if (header.containsKey(param)) {
+        throw SecurityException(
+          'Untrusted key material in JWT header',
+          details: 'Header parameter "$param" is not permitted.',
+          securityViolationType: SecurityViolationType.tokenTampered,
+        );
+      }
+    }
+
+    final alg = header['alg'] as String?;
+    if (alg == null || !_allowedAlgorithms.contains(alg)) {
+      throw SecurityException(
+        'Disallowed JWT algorithm',
+        details: 'Algorithm "$alg" is not in the accepted allowlist.',
+        securityViolationType: SecurityViolationType.invalidJwtSignature,
+      );
+    }
+  }
+
   /// Get algorithm from JWT header
   String _getAlgorithmFromToken(String token) {
     try {
@@ -351,7 +428,7 @@ class JwtValidator {
 
     // Validate nonce
     if (expectedNonce != null) {
-      if (claims.nonce != expectedNonce) {
+      if (!constantTimeEquals(claims.nonce ?? '', expectedNonce)) {
         throw const SecurityException(
           'Invalid nonce - possible replay attack',
           details: 'Nonce mismatch',
@@ -399,7 +476,7 @@ class JwtValidator {
       // Base64url encode (without padding)
       final expectedHash = base64Url.encode(leftmostBytes).replaceAll('=', '');
 
-      final isValid = expectedHash == atHash;
+      final isValid = constantTimeEquals(expectedHash, atHash);
 
       if (!isValid) {
         _logger.warning(
@@ -436,7 +513,9 @@ class JwtValidator {
       'aud': audience,
       'iat': now.millisecondsSinceEpoch ~/ 1000,
       'exp': exp.millisecondsSinceEpoch ~/ 1000,
-      'jti': jwtId ?? DateTime.now().millisecondsSinceEpoch.toString(),
+      // jti must be unique/unpredictable to prevent assertion replay; a random
+      // UUID is used rather than a timestamp (which can collide/be guessed).
+      'jti': jwtId ?? const Uuid().v4(),
     });
 
     // Create key from PEM

--- a/packages/fhir_r5_auth/lib/src/oauth/pkce.dart
+++ b/packages/fhir_r5_auth/lib/src/oauth/pkce.dart
@@ -6,7 +6,7 @@ import 'dart:convert';
 import 'dart:math';
 import 'package:crypto/crypto.dart';
 import 'package:fhir_r5_auth/fhir_r5_auth.dart'
-    show CodeChallengeMethod, OAuthParameters;
+    show CodeChallengeMethod, OAuthParameters, constantTimeEquals;
 
 /// PKCE generator for OAuth 2.0 authorization code flow
 class PkceManager {
@@ -106,7 +106,7 @@ class PkceManager {
     final expectedChallenge =
         base64Url.encode(digest.bytes).replaceAll('=', '');
 
-    return expectedChallenge == challenge;
+    return constantTimeEquals(expectedChallenge, challenge);
   }
 
   /// Reset the PKCE parameters (generates new ones on next access)

--- a/packages/fhir_r5_auth/lib/src/oauth/token_introspection.dart
+++ b/packages/fhir_r5_auth/lib/src/oauth/token_introspection.dart
@@ -9,7 +9,8 @@ import 'package:fhir_r5_auth/fhir_r5_auth.dart'
         ContentTypes,
         HttpHeaders,
         NetworkException,
-        OAuthParameters;
+        OAuthParameters,
+        assertSecureAuthUrl;
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 
@@ -174,10 +175,18 @@ class TokenIntrospector {
     required this.clientId,
     this.clientSecret,
     this.useBasicAuth = true,
+    this.allowInsecureConnections = false,
     http.Client? httpClient,
     Logger? logger,
   })  : _httpClient = httpClient ?? http.Client(),
-        _logger = logger ?? Logger('TokenIntrospector');
+        _logger = logger ?? Logger('TokenIntrospector') {
+    // The token is sent to this endpoint — it must be TLS-protected.
+    assertSecureAuthUrl(
+      introspectionEndpoint,
+      field: 'introspectionEndpoint',
+      allowInsecure: allowInsecureConnections,
+    );
+  }
 
   /// Token introspection endpoint URL
   final Uri introspectionEndpoint;
@@ -190,6 +199,10 @@ class TokenIntrospector {
 
   /// Use HTTP Basic auth for client credentials
   final bool useBasicAuth;
+
+  /// Allow a plaintext (non-HTTPS) introspection endpoint. Defaults to `false`;
+  /// loopback hosts are always permitted for local development.
+  final bool allowInsecureConnections;
 
   final http.Client _httpClient;
   final Logger _logger;

--- a/packages/fhir_r5_auth/lib/src/smart/smart_client.dart
+++ b/packages/fhir_r5_auth/lib/src/smart/smart_client.dart
@@ -25,7 +25,8 @@ import 'package:fhir_r5_auth/fhir_r5_auth.dart'
         SmartTokenResponse,
         TimeoutReason,
         TokenIntrospector,
-        WebAuthenticator;
+        WebAuthenticator,
+        assertSecureAuthUrl;
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 
@@ -131,6 +132,15 @@ class SmartFhirClient extends FhirAuthClient {
     }
 
     final sc = smartConfig!;
+
+    // PKCE is mandatory for public clients in the SMART authorization code
+    // flow; a public client must never be able to silently disable it.
+    if (sc.isPublicClient && !sc.enablePkce) {
+      throw const ConfigurationException(
+        'PKCE is required for public SMART clients',
+        configurationField: 'enablePkce',
+      );
+    }
 
     // Get endpoints if not configured
     var authEndpoint = sc.authorizeUrl;
@@ -403,9 +413,16 @@ class SmartFhirClient extends FhirAuthClient {
   Future<Map<String, dynamic>> _discoverEndpoints() async {
     _logger.fine('Discovering SMART endpoints');
 
-    // Try .well-known/smart-configuration first
+    // Try .well-known/smart-configuration first. The discovery document is the
+    // root of trust for every OAuth endpoint, so it MUST be fetched over TLS —
+    // otherwise a network attacker could substitute malicious endpoints.
     final metadataUrl =
         Uri.parse('${config.fhirBaseUrl}/.well-known/smart-configuration');
+    assertSecureAuthUrl(
+      metadataUrl,
+      field: 'fhirBaseUrl (SMART discovery)',
+      allowInsecure: config.allowInsecureConnections,
+    );
 
     try {
       final response = await _httpClient.get(metadataUrl);
@@ -472,8 +489,15 @@ class SmartFhirClient extends FhirAuthClient {
   Future<Map<String, dynamic>> _discoverFromCapabilityStatement() async {
     _logger.fine('Fetching CapabilityStatement for endpoint discovery');
 
+    final metadataUrl = Uri.parse('${config.fhirBaseUrl}/metadata');
+    assertSecureAuthUrl(
+      metadataUrl,
+      field: 'fhirBaseUrl (CapabilityStatement discovery)',
+      allowInsecure: config.allowInsecureConnections,
+    );
+
     final response = await _httpClient.get(
-      Uri.parse('${config.fhirBaseUrl}/metadata'),
+      metadataUrl,
       headers: <String, String>{'Accept': 'application/fhir+json'},
     );
 
@@ -668,6 +692,7 @@ class SmartFhirClient extends FhirAuthClient {
       introspectionEndpoint: _introspectionEndpoint!,
       clientId: config.clientId,
       clientSecret: config.clientSecret,
+      allowInsecureConnections: config.allowInsecureConnections,
       httpClient: _httpClient,
       logger: _logger,
     );

--- a/packages/fhir_r5_auth/pubspec.yaml
+++ b/packages/fhir_r5_auth/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fhir_r5_auth
 description: Secure authentication and authorization package for FHIR R5 applications implementing SMART on FHIR
-version: 0.7.1
+version: 0.7.2
 homepage: https://www.fhirfli.dev/
 repository: https://github.com/fhir-fli/fhir_r5
 issue_tracker: https://github.com/fhir-fli/fhir_r5/issues


### PR DESCRIPTION
Second security hardening pass. Library/CHANGELOG/version only (main is the publish branch; tests stay on `dev`, 419 unit tests green).

- **Concurrency:** the "prevent concurrent refreshes" lock was permanently completed and did nothing — parallel refreshes are now coalesced into one token exchange (prevents refresh-token-rotation servers from revoking the token family).
- **Availability:** refresh no longer discards the `refresh_token` when the server omits it (RFC 6749 §6).
- **Transport:** TLS now enforced on the SMART discovery documents (`.well-known/smart-configuration`, `/metadata`) and the introspection endpoint (loopback still allowed; `allowInsecureConnections` opt-out).
- **Token leakage:** the bearer token is origin-bound to the configured FHIR server (scheme/host/port).
- **EHR launch:** `SmartConfig.fromLaunchParameters` gains `allowedIssuers` to reject a spoofed `iss`.
- **JWT:** algorithm allowlist (no `alg:none`/unknown) + reject `jwk`/`jku`/`x5u`/`x5c` headers; random UUID `jti`.
- **PKCE:** cannot be disabled for a public client.
- **Timing:** constant-time comparison for `at_hash`/nonce/PKCE challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)